### PR TITLE
Update README with deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**_Warning_: This project has been deprecated. All functionality provided has been embedded within the 5.x range of [OpenConext-engineblock](https://github.com/OpenConext/OpenConext-engineblock). Any functionality changed or added must target the 4.x range of OpenConext-engineblock and should also be added to the 5.x range of OpenConext-engineblock (5.x-dev branch)**
+
 EngineBlockFixtures
 ===================
 


### PR DESCRIPTION
In [24df2bbd](https://github.com/OpenConext/OpenConext-engineblock/commit/24df2bbd8d2d8a735d2576725b479f7130e8575e) the fixtures have been embedded as part of EngineBlock. Further development should be discouraged.
